### PR TITLE
Accept an ExtensionRegistry, return a ProtoMethodDescriptorSupplier

### DIFF
--- a/src/main/java/me/dinowernli/grpc/polyglot/Main.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/Main.java
@@ -3,6 +3,8 @@ package me.dinowernli.grpc.polyglot;
 import java.util.logging.LogManager;
 
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.ExtensionRegistry;
+
 import me.dinowernli.grpc.polyglot.command.ServiceCall;
 import me.dinowernli.grpc.polyglot.command.ServiceList;
 import me.dinowernli.grpc.polyglot.config.CommandLineArgs;
@@ -62,6 +64,7 @@ public class Main {
           ServiceList.listServices(
               commandLineOutput,
               config.getProtoConfig(),
+              ExtensionRegistry.getEmptyRegistry(),
               arguments.endpoint(),
               arguments.serviceFilter(),
               arguments.methodFilter(),
@@ -73,6 +76,7 @@ public class Main {
           ServiceCall.callEndpoint(
               commandLineOutput,
               config.getProtoConfig(),
+              ExtensionRegistry.getEmptyRegistry(),
               arguments.endpoint(),
               arguments.fullMethod(),
               arguments.protoDiscoveryRoot(),

--- a/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
@@ -7,6 +7,7 @@ import com.google.common.net.HostAndPort;
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.util.JsonFormat.TypeRegistry;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -43,6 +44,7 @@ public class ServiceCall {
   public static void callEndpoint(
       Output output,
       ProtoConfiguration protoConfig,
+      ExtensionRegistry extensionRegistry,
       Optional<String> endpoint,
       Optional<String> fullMethod,
       Optional<Path> protoDiscoveryRoot,
@@ -90,7 +92,7 @@ public class ServiceCall {
     }
 
     // Set up the dynamic client and make the call.
-    ServiceResolver serviceResolver = ServiceResolver.fromFileDescriptorSet(fileDescriptorSet);
+    ServiceResolver serviceResolver = ServiceResolver.fromFileDescriptorSet(fileDescriptorSet, extensionRegistry);
     MethodDescriptor methodDescriptor = serviceResolver.resolveServiceMethod(grpcMethodName);
 
     logger.info("Creating dynamic grpc client");

--- a/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceList.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceList.java
@@ -18,6 +18,7 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Descriptors.ServiceDescriptor;
+import com.google.protobuf.ExtensionRegistry;
 
 import io.grpc.Channel;
 import io.grpc.Status;
@@ -39,6 +40,7 @@ public class ServiceList {
   public static void listServices(
       Output output,
       ProtoConfiguration protoConfig,
+      ExtensionRegistry extensionRegistry,
       Optional<String> endpoint,
       Optional<String> serviceFilter,
       Optional<String> methodFilter,
@@ -79,6 +81,7 @@ public class ServiceList {
     listServices(
         output,
         fileDescriptorSet,
+        extensionRegistry,
         protoConfig.getProtoDiscoveryRoot(),
         serviceFilter,
         methodFilter,
@@ -90,12 +93,13 @@ public class ServiceList {
   static void listServices(
       Output output,
       FileDescriptorSet fileDescriptorSet,
+      ExtensionRegistry extensionRegistry,
       String protoDiscoveryRoot,
       Optional<String> serviceFilter,
       Optional<String> methodFilter,
       Optional<Boolean> withMessage) {
 
-    ServiceResolver serviceResolver = ServiceResolver.fromFileDescriptorSet(fileDescriptorSet);
+    ServiceResolver serviceResolver = ServiceResolver.fromFileDescriptorSet(fileDescriptorSet, extensionRegistry);
 
     // Add white-space before the rendered output
     output.newLine();

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/LiteralProtoMethodDescriptorSupplier.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/LiteralProtoMethodDescriptorSupplier.java
@@ -1,0 +1,34 @@
+package me.dinowernli.grpc.polyglot.protobuf;
+
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.Descriptors.MethodDescriptor;
+import com.google.protobuf.Descriptors.ServiceDescriptor;
+
+import io.grpc.protobuf.ProtoMethodDescriptorSupplier;
+
+public class LiteralProtoMethodDescriptorSupplier implements ProtoMethodDescriptorSupplier {
+  private final MethodDescriptor methodDescriptor;
+
+  private LiteralProtoMethodDescriptorSupplier(MethodDescriptor methodDescriptor) {
+    this.methodDescriptor = methodDescriptor;
+  }
+
+  public static ProtoMethodDescriptorSupplier forMethodDescriptor(MethodDescriptor methodDescriptor) {
+    return new LiteralProtoMethodDescriptorSupplier(methodDescriptor);
+  }
+
+  @Override
+  public MethodDescriptor getMethodDescriptor() {
+    return methodDescriptor;
+  }
+
+  @Override
+  public ServiceDescriptor getServiceDescriptor() {
+    return methodDescriptor.getService();
+  }
+
+  @Override
+  public FileDescriptor getFileDescriptor() {
+    return methodDescriptor.getFile();
+  }
+}

--- a/src/test/java/me/dinowernli/grpc/polyglot/command/ServiceListTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/command/ServiceListTest.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.ExtensionRegistry;
+
 import me.dinowernli.grpc.polyglot.protobuf.WellKnownTypes;
 import me.dinowernli.grpc.polyglot.testing.RecordingOutput;
 import org.junit.Before;
@@ -38,6 +40,7 @@ public class ServiceListTest {
     ServiceList.listServices(
         recordingOutput,
         PROTO_FILE_DESCRIPTORS,
+        ExtensionRegistry.getEmptyRegistry(),
         "",
         Optional.empty(),
         Optional.empty(),
@@ -52,6 +55,7 @@ public class ServiceListTest {
     ServiceList.listServices(
         recordingOutput,
         PROTO_FILE_DESCRIPTORS,
+        ExtensionRegistry.getEmptyRegistry(),
         "",
         Optional.of("TestService"),
         Optional.empty(),
@@ -66,6 +70,7 @@ public class ServiceListTest {
     ServiceList.listServices(
         recordingOutput,
         PROTO_FILE_DESCRIPTORS,
+        ExtensionRegistry.getEmptyRegistry(),
         "",
         Optional.of("TestService"),
         Optional.of("TestMethodStream"),
@@ -83,6 +88,7 @@ public class ServiceListTest {
     ServiceList.listServices(
         recordingOutput,
         PROTO_FILE_DESCRIPTORS,
+        ExtensionRegistry.getEmptyRegistry(),
         "",
         Optional.of("TestService"),
         Optional.of("TestMethodStream"),

--- a/src/test/java/me/dinowernli/grpc/polyglot/protobuf/ServiceResolverTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/protobuf/ServiceResolverTest.java
@@ -1,6 +1,8 @@
 package me.dinowernli.grpc.polyglot.protobuf;
 
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.ExtensionRegistry;
+
 import org.junit.Before;
 import org.junit.Test;
 import polyglot.test.TestProto;
@@ -19,7 +21,9 @@ public class ServiceResolverTest {
 
   @Before
   public void setUp() {
-    serviceResolver = ServiceResolver.fromFileDescriptorSet(PROTO_FILE_DESCRIPTORS);
+    serviceResolver = ServiceResolver.fromFileDescriptorSet(
+        PROTO_FILE_DESCRIPTORS,
+        ExtensionRegistry.getEmptyRegistry());
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
This adds an `ExtensionRegistry` as a parameter and also sets a `ProtoMethodDescriptorSupplier` on the `MethodDescriptor`. This useful if you have interceptors which use the `ProtoMethodDescriptorSupplier` to find extensions and apply customizations